### PR TITLE
Bug fix: RegEx in username validation at registration

### DIFF
--- a/src/routes/api/register/+server.ts
+++ b/src/routes/api/register/+server.ts
@@ -22,7 +22,7 @@ export async function POST({ request }: { request: Request }) {
   }
 
   if (
-    !new RegExp("^[A-z0-9_](?:[A-Za-z0-9._]{2,18}[A-Za-z0-9_])?$").test(
+    !new RegExp("^[A-Za-z0-9_][A-Za-z0-9._]{2,18}[A-Za-z0-9_]$").test(
       username,
     )
   ) {


### PR DESCRIPTION
Current code allows users to create one-character usernames from the set `[A-z0-9_]`, which additionally includes characters like `\` and `[` (because `A-z` includes unicode characters 91 through 96!)

The new expression removes an unneeded non-capturing group and the optional quantifier, forcing there to be at least 4 characters with the allowed ones considered at the beginning and end. Feel free to change the quantifier in the middle for your needs!